### PR TITLE
Merge pull request #105 from cisagov/dependabot/pip/cryptography-43.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ blinker==1.6.2
 boolean.py==4.0
 cffi==1.16.0
 click==8.1.7
-cryptography==42.0.5
+cryptography==43.0.1
 Flask==2.3.2
 Flask-Login==0.6.3
 Flask-Principal==0.4.0


### PR DESCRIPTION
Bump cryptography from 42.0.5 to 43.0.1